### PR TITLE
Jenkins: Prefer IPv4 switch

### DIFF
--- a/roles/jenkins/defaults/main.yml
+++ b/roles/jenkins/defaults/main.yml
@@ -4,6 +4,8 @@ jenkins_group: "edx"
 jenkins_server_name: "jenkins-ci.analytics.edx.org"
 jenkins_port: 8080
 
+jenkins_prefer_ipv4: true
+
 jenkins_version: "1.559"
 jenkins_deb_url: "http://pkg.jenkins-ci.org/debian/binary/jenkins_{{ jenkins_version }}_all.deb"
 jenkins_deb: "jenkins_{{ jenkins_version }}_all.deb"

--- a/roles/jenkins/templates/etc/default/jenkins.j2
+++ b/roles/jenkins/templates/etc/default/jenkins.j2
@@ -6,8 +6,11 @@ NAME=jenkins
 # location of java
 JAVA=/usr/bin/java
 
+# Prefer IPv4 stack
+PREFER_IPV4="-Djava.net.preferIPv4Stack={{ jenkins_prefer_ipv4 }}"
+
 # arguments to pass to java
-JAVA_ARGS="-Djava.awt.headless=true -Djava.io.tmpdir=/var/tmp -Xmx{{ jenkins_heap_size }}"  # Allow graphs etc. to work even when an X server is present
+JAVA_ARGS="-Djava.awt.headless=true -Djava.io.tmpdir=/var/tmp -Xmx{{ jenkins_heap_size }} $PREFER_IPV4"  # Allow graphs etc. to work even when an X server is present
 
 PIDFILE=/var/run/jenkins/jenkins.pid
 

--- a/roles/jenkins/templates/etc/nginx/sites-available/jenkins.j2
+++ b/roles/jenkins/templates/etc/nginx/sites-available/jenkins.j2
@@ -3,7 +3,11 @@ server {
   server_name {{ jenkins_server_name }};
 
   location / {
+    {% if jenkins_prefer_ipv4 %}
     proxy_pass              http://localhost:{{ jenkins_port }};
+    {% else %}
+    proxy_pass              http://[::1]:{{ jenkins_port }};
+    {% endif %}
 
     {% if jenkins_protocol == 'https' %}
     # Rewrite HTTPS requests from WAN to HTTP requests on LAN


### PR DESCRIPTION
**Description:** By default jenkins binds on tcpv6 address, mking nginx redirect in jenkins broken, as it binds to ipv4 address only.